### PR TITLE
feat/graylog: remove meta dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,11 +1,6 @@
 ---
 
-dependencies:
-  - role: "elastic.elasticsearch"
-    when: graylog_install_elasticsearch
-
-  - role: "jdauphant.nginx"
-    when: graylog_install_nginx
+dependencies: []
 
 galaxy_info:
   author: "Marius Sturm"


### PR DESCRIPTION
This dependencies broken the installation. We dont need this because we use separated roles to install which dependence.